### PR TITLE
Update socketcan version

### DIFF
--- a/node-red-contrib-canbus/package.json
+++ b/node-red-contrib-canbus/package.json
@@ -6,7 +6,7 @@
   },
   "description": "A set of node-red nodes used for socketcan utilities",
   "dependencies": {
-    "socketcan": "2.1.x",
+    "socketcan": "2.4.x",
     "random-js": "1.0.x"
   },
   "author": {

--- a/node-red-contrib-canbus/package.json
+++ b/node-red-contrib-canbus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-canbus",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "engines": {
     "node": "=0.12.x"
   },


### PR DESCRIPTION
Should fix #4. 
The are still deprecation warnings on build, but those are still related to `socketcan`